### PR TITLE
Remove almost all GCC warnings

### DIFF
--- a/src/librarian.c
+++ b/src/librarian.c
@@ -118,6 +118,8 @@ int FinalizeNeededLib(lib_t* maplib, const char* path, box86context_t* box86, x8
         printf_log(LOG_DEBUG, "Failure to finalizing lib => fail\n");
         return 1;
     }
+    
+    return 0;
 }
 
 library_t* GetLib(lib_t* maplib, const char* name)

--- a/src/pathcoll.c
+++ b/src/pathcoll.c
@@ -48,7 +48,7 @@ void ParseList(const char* List, path_collection_t* collection)
     while(p) {
         const char *p2 = strchr(p, ':');
         if(!p2) {
-            strncpy(tmp, p, MAX_PATH);
+            strncpy(tmp, p, MAX_PATH - 1);
             p=NULL;
         } else {
             int l = (uintptr_t)p2 - (uintptr_t)p;

--- a/src/run0f.h
+++ b/src/run0f.h
@@ -354,7 +354,7 @@
             for(int i=0; i<4; ++i)
                 GM.ub[i] = (GM.sw[i]<0)?0:((GM.sw[i]>0xff)?0xff:GM.sw[i]);
             for(int i=0; i<4; ++i)
-                GM.ub[8+i] = (EM->sw[i]<0)?0:((EM->sw[i]>0xff)?0xff:EM->sw[i]);
+                GM.ub[4+i] = (EM->sw[i]<0)?0:((EM->sw[i]>0xff)?0xff:EM->sw[i]);
             NEXT;
 
         _0f_0x68:                       /* PUNPCKHBW Gm,Em */
@@ -396,10 +396,10 @@
             tmp8u = F8;
             if(&GM!=EM) {
                 for(int i=0; i<4; ++i)
-                    GM.uw[i] = EX->uw[(tmp8u>>(i*2))&3];
+                    GM.uw[i] = EM->uw[(tmp8u>>(i*2))&3];
             } else {
                 for(int i=0; i<4; ++i)
-                    eax1.uw[i] = EX->uw[(tmp8u>>(i*2))&3];
+                    eax1.uw[i] = EM->uw[(tmp8u>>(i*2))&3];
                 GM.q = eax1.q[0];
             }
             NEXT;

--- a/src/run66.h
+++ b/src/run66.h
@@ -308,6 +308,8 @@
                 }
                 break;
             case 0xA7:              /* REP(N)Z CMPSW */
+                tmp16u = 0;
+                tmp16u2 = 0;
                 while(tmp32u) {
                     --tmp32u;
                     tmp16u  = *(uint16_t*)R_EDI;
@@ -334,6 +336,7 @@
                 }
                 break;
             case 0xAF:              /* REP(N)Z SCASW */
+                tmp16u = 0;
                 while(tmp32u) {
                     --tmp32u;
                     tmp16u = *(uint16_t*)R_EDI;
@@ -397,6 +400,3 @@
                 goto fini;
         }
         NEXT;
-                
-
-

--- a/src/rund8.h
+++ b/src/rund8.h
@@ -1,3 +1,5 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     nextop = F8;
     switch(nextop) {
         case 0xC0:
@@ -240,3 +242,4 @@
                 goto _default;
         }
     }
+#pragma GCC diagnostic pop

--- a/src/rund9.h
+++ b/src/rund9.h
@@ -1,3 +1,5 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     nextop = F8;
     switch (nextop) {
         case 0xC0:
@@ -319,3 +321,4 @@
                 goto _default;
         }
     }
+#pragma GCC diagnostic pop

--- a/src/rundc.h
+++ b/src/rundc.h
@@ -1,3 +1,5 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
     nextop = F8;
     switch(nextop) {
         case 0xC0:
@@ -239,3 +241,4 @@
                 goto _default;
         }
     }
+#pragma GCC diagnostic pop

--- a/src/wrappedlibc.c
+++ b/src/wrappedlibc.c
@@ -361,9 +361,11 @@ EXPORT int my___swprintf_chk(x86emu_t* emu, void* s, uint32_t n, int32_t flag, u
     myStackAlignW((const char*)fmt, b, emu->scratch);
     void* f = vswprintf;
     int r = ((iFpupp_t)f)(s, n, fmt, emu->scratch);
+    return r;
     #else
     void* f = vswprintf;
-    ((iFpupp_t)f)(s, n, fmt, b);
+    int r = ((iFpupp_t)f)(s, n, fmt, b);
+    return r;
     #endif
 }
 EXPORT int my_swprintf(x86emu_t* emu, void* s, uint32_t n, void* fmt, void *b)
@@ -372,9 +374,11 @@ EXPORT int my_swprintf(x86emu_t* emu, void* s, uint32_t n, void* fmt, void *b)
     myStackAlignW((const char*)fmt, b, emu->scratch);
     void* f = vswprintf;
     int r = ((iFpupp_t)f)(s, n, fmt, emu->scratch);
+    return r;
     #else
     void* f = vswprintf;
-    ((iFpupp_t)f)(s, n, fmt, b);
+    int r = ((iFpupp_t)f)(s, n, fmt, b);
+    return r;
     #endif
 }
 

--- a/src/wrappedvorbisfile.c
+++ b/src/wrappedvorbisfile.c
@@ -472,7 +472,6 @@ GO(4)
 GO(5)
 GO(6)
 GO(7)
-GO(8)
 #undef GO
 #define GO(A) {my_read_func_##A, my_seek_func_##A, my_close_func_##A, my_tell_func_##A},
 static ov_callbacks my_ov_callbacks[] = {
@@ -484,7 +483,6 @@ GO(4)
 GO(5)
 GO(6)
 GO(7)
-GO(8)
 };
 #undef GO
 

--- a/src/x86int3.c
+++ b/src/x86int3.c
@@ -74,11 +74,11 @@ void x86Int3(x86emu_t* emu)
             if(box86_log>=LOG_DEBUG /*&& emu->trace_end==0 && !emu->context->x86trace*/) {
                 pthread_mutex_lock(&emu->context->mutex_trace);
                 char buff[256] = "\0";
-                char buff2[64]= "\0";
-                char buff3[64]= "\0";
+                char buff2[64] = "\0";
+                char buff3[64] = "\0";
                 int post = 0;
                 int perr = 0;
-                uint32_t *pu32;
+                uint32_t *pu32 = NULL;
                 const char *s = GetNativeName((void*)addr);
                 if(addr==(uintptr_t)PltResolver) {
                     snprintf(buff, 256, "%s", " ... ");

--- a/src/x86run.c
+++ b/src/x86run.c
@@ -204,7 +204,10 @@ x86emurun:
 _trace:
     if(start_cnt) --start_cnt;
     emu->prev2_ip = emu->prev_ip;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     emu->prev_ip = old_ip;
+#pragma GCC diagnostic pop
     old_ip = ip;
     if(!start_cnt && emu->dec && (
             (emu->trace_end == 0) 
@@ -1217,6 +1220,8 @@ _trace:
                         }
                         break;
                     case 0xA6:              /* REP(N)Z CMPSB */
+                        tmp8u = 0;
+                        tmp8u2 = 0;
                         if(opcode==0xF2) {
                             while(tmp32u) {
                                 --tmp32u;
@@ -1241,6 +1246,8 @@ _trace:
                         if(R_ECX) cmp8(emu, tmp8u2, tmp8u);
                         break;
                     case 0xA7:              /* REP(N)Z CMPSD */
+                        tmp32u2 = 0;
+                        tmp32u3 = 0;
                         tmp8s *= 4;
                         if(opcode==0xF2) {
                             while(tmp32u) {
@@ -1296,6 +1303,7 @@ _trace:
                         }
                         break;
                     case 0xAE:              /* REP(N)Z SCASB */
+                        tmp8u = 0;
                         if(opcode==0xF2) {
                             while(tmp32u) {
                                 --tmp32u;
@@ -1316,6 +1324,7 @@ _trace:
                         if(R_ECX) cmp8(emu, R_AL, tmp8u);
                         break;
                     case 0xAF:              /* REP(N)Z SCASD */
+                        tmp32u2 = 0;
                         tmp8s *= 4;
                         if(opcode==0xF2) {
                             while(tmp32u) {

--- a/src/x87emu_private.c
+++ b/src/x87emu_private.c
@@ -112,7 +112,7 @@ void LD2D(void* ld, void* d)
 	int32_t exp64 = (((uint32_t)(val.b&0x7fff) - BIAS80) + BIAS64);
 	int32_t exp64final = exp64&0x7ff;
     // do specific value first (0, infinite...)
-    // bit 63 is "intetger part"
+    // bit 63 is "integer part"
     // bit 62 is sign
     if((uint32_t)(val.b&0x7fff)==0x7fff) {
         // infinity and nans
@@ -126,7 +126,7 @@ void LD2D(void* ld, void* d)
         if(t) {    // infinite
             result.d = HUGE_VAL;
         } else {      // NaN
-            result.l.upper |= 0x7ff << 20;
+            result.l.upper = 0x7ff << 20;
             result.l.lower = 0;
         }
         if(val.b&0x8000)

--- a/src/x87emu_private.h
+++ b/src/x87emu_private.h
@@ -165,6 +165,8 @@ static inline double fpu_round(x86emu_t* emu, double d) {
             return ceil(d);
         case ROUND_Chop:
             return round(d);
+        default:
+            return 0;
     }
 }
 #endif


### PR DESCRIPTION
This PR removes all GCC warnings (using GCC 9.1.1 20190503 with `-Wall`) except for all ...`unused`... warnings.
It also fixes some potential bugs, the most critical ones being in `run0f.h` (this one needs to be checked).