### PR TITLE
Fixes

### DIFF
--- a/rebuild_wrappers.py
+++ b/rebuild_wrappers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import glob

--- a/src/emu/x86int3.c
+++ b/src/emu/x86int3.c
@@ -51,7 +51,7 @@ x86emu_t* x86emu_fork(x86emu_t* e, int forktype)
     if(v==EAGAIN || v==ENOMEM) {
         --emu->context->forked;
         FreeX86Emu(&newemu);    // fork failed, free the new emu
-    } else if(!v) {  
+    } else if(v!=0) {  
         // execute atforks parent functions
         for (int i=0; i<emu->context->atfork_sz; --i)
             EmuCall(emu, emu->context->atforks[i].parent);

--- a/src/wrapped/wrappedlib_init.h
+++ b/src/wrapped/wrappedlib_init.h
@@ -46,7 +46,7 @@ static const map_onesymbol_t MAPNAME(mysymbolmap)[] = {
 #define GOM(N, W)
 #undef GOS
 #define GOS(N, W) {#N, W, 0},
-static const map_onesymbol2_t MAPNAME(stsymbolmap)[] = {
+static const map_onesymbol_t MAPNAME(stsymbolmap)[] = {
     #include PRIVATE(LIBNAME)
 };
 #undef GOS
@@ -226,4 +226,3 @@ int FUNC(_getnoweak)(library_t* lib, const char* name, uintptr_t *offs, uint32_t
     *sz = size;
     return 1;
 }
-


### PR DESCRIPTION
This PR fixes 3 things:
- If `env python` is not python 2, the `rebuild_wrappers.py` script fails;
- The `x86emu_fork` function does not differentiate between the parent and the child process (it always execute the parent only);
- The *stsymbolmap (libcstsymbolmap...) has the wrong type and is missing one element when using the`GOS` macro.