### PR TITLE
Fixed the PSRAQ instruction

### DIFF
--- a/src/emu/run0f.h
+++ b/src/emu/run0f.h
@@ -1057,10 +1057,10 @@
         _0f_0xE3:                   /* PSRAQ Gm, Em */
             nextop = F8;
             GET_EM;
-            if (EM->q > 63) {
-                GM.q = (GM.q < 0) ? -1 : 0;
+            if (EM->sq > 63) {
+                GM.sq = (GM.sq < 0) ? -1 : 0;
             } else {
-                GM.q >>= EM->q;
+                GM.sq >>= EM->sq;
             }
             NEXT;
 

--- a/src/include/regs.h
+++ b/src/include/regs.h
@@ -196,6 +196,7 @@ typedef union {
 
 typedef union {
 	uint64_t	q;
+	int64_t		sq;
 	uint32_t	ud[2];
 	int32_t 	sd[2];
 	uint16_t 	uw[4];


### PR DESCRIPTION
This PR fixes the PSRAQ instruction, by using signed registers instead of unsigned.