### PR TITLE
Include sysmacros.h in elfloader.c

### DIFF
--- a/src/elfs/elfloader.c
+++ b/src/elfs/elfloader.c
@@ -5,6 +5,7 @@
 #include <elf.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <link.h>
 #include <unistd.h>


### PR DESCRIPTION
Some compilers (like the one on the GameShell) need this to be included or you get undefined references to "major," "minor," and "makedev."

The result is a build failure.