### PR TITLE
Fix 64bit inodes in readdir and readdir_r functions

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -120,3 +120,7 @@ Allow box86 to continue even if a lib is missing
  * 0 : default, stop if a lib cannot be loaded
  * 1 : continue even if a needed lib cannot be loaded. Unadvised, this will, in most cases, crash later on.
 
+#### BOX86_FIX_64BIT_INODES
+ * 0 : Don't fix 64bit inodes (default)
+ * 1 : Fix 64bit inodes. Helps when running on filesystems with 64bit inodes, the program uses API functions which don't support it and the program doesn't use inodes information.
+

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -1342,10 +1342,10 @@ GO(read, iFipu)
 GOW(__read, iFipu)
 // readahead    // Weak
 GO(__read_chk, iFipuu)
-GOW(readdir, pFp)
+GOM(readdir, pFEp)  // should also be weak
 GO(readdir64, pFp)  // check if alignement is correct
 // readdir64_r
-GOW(readdir_r, iFppp)
+GOM(readdir_r, iFEppp)  // should also be weak
 GOM(readlink, iFEppu)
 GO(readlinkat, iFippu)
 // __readlinkat_chk


### PR DESCRIPTION
This continues the last pull request (#123).