### PR TITLE
Allow compilation with older version of glibc

### DIFF
--- a/src/emu/x86syscall.c
+++ b/src/emu/x86syscall.c
@@ -44,6 +44,10 @@
 //#define SYS_SENDMMSG    20
 //#endif
 int32_t my_accept4(x86emu_t* emu, int32_t fd, void* a, void* l, int32_t flags); // not always present, so used wrapped version
+#ifdef SYS_RECVMMSG
+int32_t my_recvmmsg(x86emu_t* emu, int32_t fd, void* msgvec, uint32_t vlen, uint32_t flags, void* timeout);
+int32_t my___sendmmsg(x86emu_t* emu, int32_t fd, void* msgvec, uint32_t vlen, uint32_t flags);
+#endif
 #endif
 
 
@@ -390,9 +394,8 @@ void EXPORT x86Syscall(x86emu_t *emu)
                     case SYS_RECVMSG: R_EAX = recvmsg(args[0], (void*)args[1], args[2]); break;
                     case SYS_ACCEPT4: R_EAX = my_accept4(emu, args[0], (void*)args[1], (void*)args[2], args[3]); break;
                     #ifdef SYS_RECVMMSG
-                    // TODO: Create my_ version of recvmmsg and sendmmsg
-                    case SYS_RECVMMSG: R_EAX = recvmmsg(args[0], (void*)args[1], args[2], args[3], (void*)args[4]); break;
-                    case SYS_SENDMMSG: R_EAX = sendmmsg(args[0], (void*)args[1], args[2], args[3]); break;
+                    case SYS_RECVMMSG: R_EAX = my_recvmmsg(emu, args[0], (void*)args[1], args[2], args[3], (void*)args[4]); break;
+                    case SYS_SENDMMSG: R_EAX = my___sendmmsg(emu, args[0], (void*)args[1], args[2], args[3]); break;
                     #endif
                     default:
                         printf_log(LOG_DEBUG, "BOX86 Error on Syscall 102: Unknown Soket command %d\n", R_EBX);

--- a/src/main.c
+++ b/src/main.c
@@ -19,7 +19,7 @@
 #ifdef DYNAREC
 #include <unistd.h>
 #ifdef ARM
-#include <sys/auxv.h>
+#include <linux/auxvec.h>
 #include <asm/hwcap.h>
 #endif
 #endif

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -130,6 +130,7 @@ typedef int32_t (*iFpipp_t)(void*, int32_t, void*, void*);
 typedef int32_t (*iFppii_t)(void*, void*, int32_t, int32_t);
 typedef int32_t (*iFipuu_t)(int32_t, void*, uint32_t, uint32_t);
 typedef int32_t (*iFipiI_t)(int32_t, void*, int32_t, int64_t);
+typedef int32_t (*iFipuup_t)(int32_t, void*, uint32_t, uint32_t, void*);
 typedef int32_t (*iFiiuuuuuu_t)(int32_t, int32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t);
 typedef void* (*pFp_t)(void*);
 
@@ -1560,6 +1561,18 @@ EXPORT int32_t my_getrandom(x86emu_t* emu, void* buf, uint32_t buflen, uint32_t 
     uint32_t r = fread(buf, 1, buflen, rnd);
     fclose(rnd);
     return r;
+}
+
+EXPORT int32_t my_recvmmsg(x86emu_t* emu, int32_t fd, void* msgvec, uint32_t vlen, uint32_t flags, void* timeout)
+{
+    // Implemented starting glibc 2.12+
+    library_t* lib = GetLibInternal(libcName);
+    if(!lib) return 0;
+    void* f = dlsym(lib->priv.w.lib, "recvmmsg");
+    if(f)
+        return ((iFipuup_t)f)(fd, msgvec, vlen, flags, timeout);
+    // Use the syscall
+    return syscall(__NR_recvmmsg, fd, msgvec, vlen, flags, timeout);
 }
 
 EXPORT int32_t my___sendmmsg(x86emu_t* emu, int32_t fd, void* msgvec, uint32_t vlen, uint32_t flags)

--- a/src/wrapped/wrappedlibc_private.h
+++ b/src/wrapped/wrappedlibc_private.h
@@ -1363,6 +1363,7 @@ GO(recv, iFipui)
 GO(__recv_chk, iFipuui)
 GOW(recvfrom, iFipuipp)
 // __recvfrom_chk
+GOM(recvmmsg, iFEipuup)    // actual recvmmsg is glibc 2.12+. The syscall is Linux 2.6.33+, so use syscall...
 GOW(recvmsg, iFipi)
 // re_exec  // Weak
 GOW(regcomp, iFppi)


### PR DESCRIPTION
Older versions of glibc (like the one on Pandora) don't have include sys/auxv.h, but include linux/auxvec.h contains definitions used by box86.
Older versions of glibc also don't have recvmmsg and sendmmsg, so I replaced them with my_ versions.