### PR TITLE
Fixed the U/SXT* opcodes print (and probably others too)

### DIFF
--- a/rebuild_printer.py
+++ b/rebuild_printer.py
@@ -617,6 +617,7 @@ def main(root, ver, __debug_forceAllDebugging=False):
 						text = text.replace("{!}", "%s")
 						printf_args = printf_args + ", (w ? \"!\" : \"\")"
 					
+					skiprbr = False
 					if idx % 2:
 						if text == "c":
 							if variables["cond"] != -1:
@@ -653,6 +654,7 @@ def main(root, ver, __debug_forceAllDebugging=False):
 						elif text == "rotation":
 							if output.endswith("{, "):
 								output = output[:-3]
+								skiprbr = True
 							append("%s")
 							printf_args = printf_args + ", tmprot"
 						elif text == "label":
@@ -690,8 +692,6 @@ def main(root, ver, __debug_forceAllDebugging=False):
 						
 						text = text.split('\\')
 						while len(text) > 1:
-							if text[0][0] == "}":
-								text[0] = text[0][1:]
 							if text[1][0] == '%':
 								modifier, text[1] = '%', text[1][1:]
 								while (len(text[1]) > 1) \
@@ -705,7 +705,7 @@ def main(root, ver, __debug_forceAllDebugging=False):
 							text = text[2:]
 						if len(text) == 0:
 							fail(AssertionError, "Substitution not finished")
-						if text[0][0] == "}":
+						if skiprbr and (text[0][0] == "}"):
 							text[0] = text[0][1:]
 						append(text[0])
 					

--- a/rebuild_printer.py
+++ b/rebuild_printer.py
@@ -690,6 +690,8 @@ def main(root, ver, __debug_forceAllDebugging=False):
 						
 						text = text.split('\\')
 						while len(text) > 1:
+							if text[0][0] == "}":
+								text[0] = text[0][1:]
 							if text[1][0] == '%':
 								modifier, text[1] = '%', text[1][1:]
 								while (len(text[1]) > 1) \
@@ -703,6 +705,8 @@ def main(root, ver, __debug_forceAllDebugging=False):
 							text = text[2:]
 						if len(text) == 0:
 							fail(AssertionError, "Substitution not finished")
+						if text[0][0] == "}":
+							text[0] = text[0][1:]
 						append(text[0])
 					
 					curSplt = curSplt + 1

--- a/src/wrapped/generated/functions_list.txt
+++ b/src/wrapped/generated/functions_list.txt
@@ -975,6 +975,7 @@
 #() vFpppppp
 #() iFEiippi
 #() iFEiippp
+#() iFEipuup
 #() iFEipppi
 #() iFEpiipp
 #() iFEpiipV

--- a/src/wrapped/generated/wrapper.c
+++ b/src/wrapped/generated/wrapper.c
@@ -1021,6 +1021,7 @@ typedef void (*vFpppppL_t)(void*, void*, void*, void*, void*, uintptr_t);
 typedef void (*vFpppppp_t)(void*, void*, void*, void*, void*, void*);
 typedef int32_t (*iFEiippi_t)(x86emu_t*, int32_t, int32_t, void*, void*, int32_t);
 typedef int32_t (*iFEiippp_t)(x86emu_t*, int32_t, int32_t, void*, void*, void*);
+typedef int32_t (*iFEipuup_t)(x86emu_t*, int32_t, void*, uint32_t, uint32_t, void*);
 typedef int32_t (*iFEipppi_t)(x86emu_t*, int32_t, void*, void*, void*, int32_t);
 typedef int32_t (*iFEpiipp_t)(x86emu_t*, void*, int32_t, int32_t, void*, void*);
 typedef int32_t (*iFEpiipV_t)(x86emu_t*, void*, int32_t, int32_t, void*, void*);
@@ -2547,6 +2548,7 @@ void vFpppppL(x86emu_t *emu, uintptr_t fcn) { vFpppppL_t fn = (vFpppppL_t)fcn; f
 void vFpppppp(x86emu_t *emu, uintptr_t fcn) { vFpppppp_t fn = (vFpppppp_t)fcn; fn(*(void**)(R_ESP + 4), *(void**)(R_ESP + 8), *(void**)(R_ESP + 12), *(void**)(R_ESP + 16), *(void**)(R_ESP + 20), *(void**)(R_ESP + 24)); }
 void iFEiippi(x86emu_t *emu, uintptr_t fcn) { iFEiippi_t fn = (iFEiippi_t)fcn; R_EAX=fn(emu, *(int32_t*)(R_ESP + 4), *(int32_t*)(R_ESP + 8), *(void**)(R_ESP + 12), *(void**)(R_ESP + 16), *(int32_t*)(R_ESP + 20)); }
 void iFEiippp(x86emu_t *emu, uintptr_t fcn) { iFEiippp_t fn = (iFEiippp_t)fcn; R_EAX=fn(emu, *(int32_t*)(R_ESP + 4), *(int32_t*)(R_ESP + 8), *(void**)(R_ESP + 12), *(void**)(R_ESP + 16), *(void**)(R_ESP + 20)); }
+void iFEipuup(x86emu_t *emu, uintptr_t fcn) { iFEipuup_t fn = (iFEipuup_t)fcn; R_EAX=fn(emu, *(int32_t*)(R_ESP + 4), *(void**)(R_ESP + 8), *(uint32_t*)(R_ESP + 12), *(uint32_t*)(R_ESP + 16), *(void**)(R_ESP + 20)); }
 void iFEipppi(x86emu_t *emu, uintptr_t fcn) { iFEipppi_t fn = (iFEipppi_t)fcn; R_EAX=fn(emu, *(int32_t*)(R_ESP + 4), *(void**)(R_ESP + 8), *(void**)(R_ESP + 12), *(void**)(R_ESP + 16), *(int32_t*)(R_ESP + 20)); }
 void iFEpiipp(x86emu_t *emu, uintptr_t fcn) { iFEpiipp_t fn = (iFEpiipp_t)fcn; R_EAX=fn(emu, *(void**)(R_ESP + 4), *(int32_t*)(R_ESP + 8), *(int32_t*)(R_ESP + 12), *(void**)(R_ESP + 16), *(void**)(R_ESP + 20)); }
 void iFEpiipV(x86emu_t *emu, uintptr_t fcn) { iFEpiipV_t fn = (iFEpiipV_t)fcn; R_EAX=fn(emu, *(void**)(R_ESP + 4), *(int32_t*)(R_ESP + 8), *(int32_t*)(R_ESP + 12), *(void**)(R_ESP + 16), (void*)(R_ESP + 20)); }

--- a/src/wrapped/generated/wrapper.h
+++ b/src/wrapped/generated/wrapper.h
@@ -1002,6 +1002,7 @@ void vFpppppL(x86emu_t *emu, uintptr_t fnc);
 void vFpppppp(x86emu_t *emu, uintptr_t fnc);
 void iFEiippi(x86emu_t *emu, uintptr_t fnc);
 void iFEiippp(x86emu_t *emu, uintptr_t fnc);
+void iFEipuup(x86emu_t *emu, uintptr_t fnc);
 void iFEipppi(x86emu_t *emu, uintptr_t fnc);
 void iFEpiipp(x86emu_t *emu, uintptr_t fnc);
 void iFEpiipV(x86emu_t *emu, uintptr_t fnc);


### PR DESCRIPTION
This PR fixes the printer generator for ARM (no shift) instructions with an optional rotation or other optional