### PR TITLE
Fixed ARMS (ARM shifted) instruction category

### DIFF
--- a/rebuild_printer.py
+++ b/rebuild_printer.py
@@ -817,7 +817,7 @@ def main(root, ver, __debug_forceAllDebugging=False):
 					fail(NotImplementedError, "Unknown case with shift")
 				
 				if (spltln[0] == "ARMS"):
-					generate_bin_test([24, 27], [[(0, 0), (0, 0)], [(1, 0), (1, 1)]])
+					generate_bin_test([24, 27], [[(0, 0), (1, 0)], [(1, 0), (1, 1)]])
 				else:
 					generate_bin_test()
 				

--- a/src/dynarec/arm_printer.c
+++ b/src/dynarec/arm_printer.c
@@ -3170,7 +3170,7 @@ const char* arm_print(uint32_t opcode) {
 		strcpy(ret, "???");
 	} else if ((opcode & 0xF0000000) == 0xF0000000) {
 		strcpy(ret, "???");
-	} else if (((opcode & 0x0FE00000) == 0x00000000) || ((opcode & 0x0FE00090) == 0x00000010)) {
+	} else if (((opcode & 0x0FE00010) == 0x00000000) || ((opcode & 0x0FE00090) == 0x00000010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3235,7 +3235,7 @@ const char* arm_print(uint32_t opcode) {
 		int u = (opcode >> 23) & 1;
 		
 		sprintf(ret, "LDRSH%s %s, [%s], %s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm]);
-	} else if (((opcode & 0x0FE00000) == 0x00200000) || ((opcode & 0x0FE00090) == 0x00200010)) {
+	} else if (((opcode & 0x0FE00010) == 0x00200000) || ((opcode & 0x0FE00090) == 0x00200010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3285,7 +3285,7 @@ const char* arm_print(uint32_t opcode) {
 		int u = (opcode >> 23) & 1;
 		
 		sprintf(ret, "LDRSHT%s %s, [%s], %s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm]);
-	} else if (((opcode & 0x0FE00000) == 0x00400000) || ((opcode & 0x0FE00090) == 0x00400010)) {
+	} else if (((opcode & 0x0FE00010) == 0x00400000) || ((opcode & 0x0FE00090) == 0x00400010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3350,7 +3350,7 @@ const char* arm_print(uint32_t opcode) {
 		uint8_t imm8 = (((opcode >> 8) & 0xF) << 4) | ((opcode >> 0) & 0xF);
 		
 		sprintf(ret, "LDRSH%s %s, [%s], #%s%d", cond, regname[rt], regname[rn], (u ? "" : "-"), imm8);
-	} else if (((opcode & 0x0FE00000) == 0x00600000) || ((opcode & 0x0FE00090) == 0x00600010)) {
+	} else if (((opcode & 0x0FE00010) == 0x00600000) || ((opcode & 0x0FE00090) == 0x00600010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3399,7 +3399,7 @@ const char* arm_print(uint32_t opcode) {
 		uint8_t imm8 = (((opcode >> 8) & 0xF) << 4) | ((opcode >> 0) & 0xF);
 		
 		sprintf(ret, "LDRSHT%s %s, [%s], #%s%d", cond, regname[rt], regname[rn], (u ? "" : "-"), imm8);
-	} else if (((opcode & 0x0FE00000) == 0x00800000) || ((opcode & 0x0FE00090) == 0x00800010)) {
+	} else if (((opcode & 0x0FE00010) == 0x00800000) || ((opcode & 0x0FE00090) == 0x00800010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3417,7 +3417,7 @@ const char* arm_print(uint32_t opcode) {
 		int rm = (opcode >> 8) & 0xF;
 		
 		sprintf(ret, "UMULL%s%s %s, %s, %s, %s", (s ? "S" : ""), cond, regname[rdlo], regname[rdhi], regname[rn], regname[rm]);
-	} else if (((opcode & 0x0FE00000) == 0x00A00000) || ((opcode & 0x0FE00090) == 0x00A00010)) {
+	} else if (((opcode & 0x0FE00010) == 0x00A00000) || ((opcode & 0x0FE00090) == 0x00A00010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3435,7 +3435,7 @@ const char* arm_print(uint32_t opcode) {
 		int rm = (opcode >> 8) & 0xF;
 		
 		sprintf(ret, "UMLAL%s%s %s, %s, %s, %s", (s ? "S" : ""), cond, regname[rdlo], regname[rdhi], regname[rn], regname[rm]);
-	} else if (((opcode & 0x0FE00000) == 0x00C00000) || ((opcode & 0x0FE00090) == 0x00C00010)) {
+	} else if (((opcode & 0x0FE00010) == 0x00C00000) || ((opcode & 0x0FE00090) == 0x00C00010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3453,7 +3453,7 @@ const char* arm_print(uint32_t opcode) {
 		int rm = (opcode >> 8) & 0xF;
 		
 		sprintf(ret, "SMULL%s%s %s, %s, %s, %s", (s ? "S" : ""), cond, regname[rdlo], regname[rdhi], regname[rn], regname[rm]);
-	} else if (((opcode & 0x0FE00000) == 0x00E00000) || ((opcode & 0x0FE00090) == 0x00E00010)) {
+	} else if (((opcode & 0x0FE00010) == 0x00E00000) || ((opcode & 0x0FE00090) == 0x00E00010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3537,7 +3537,7 @@ const char* arm_print(uint32_t opcode) {
 		int w = (opcode >> 21) & 1;
 		
 		sprintf(ret, "STRD%s %s, %s, [%s, %s%s]%s", cond, regname[rt], regname[rt + 1], regname[rn], (u ? "" : "-"), regname[rm], (w ? "!" : ""));
-	} else if (((opcode & 0x0FF00000) == 0x01100000) || ((opcode & 0x0FF00090) == 0x01100010)) {
+	} else if (((opcode & 0x0FF00010) == 0x01100000) || ((opcode & 0x0FF00090) == 0x01100010)) {
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
@@ -3590,7 +3590,7 @@ const char* arm_print(uint32_t opcode) {
 		uint16_t imm16 = (((opcode >> 8) & 0xFFF) << 4) | ((opcode >> 0) & 0xF);
 		
 		sprintf(ret, "BKPT #0x%x", imm16);
-	} else if (((opcode & 0x0FF00000) == 0x01300000) || ((opcode & 0x0FF00090) == 0x01300010)) {
+	} else if (((opcode & 0x0FF00010) == 0x01300000) || ((opcode & 0x0FF00090) == 0x01300010)) {
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
@@ -3631,14 +3631,14 @@ const char* arm_print(uint32_t opcode) {
 		uint8_t imm8 = (((opcode >> 8) & 0xF) << 4) | ((opcode >> 0) & 0xF);
 		
 		sprintf(ret, "STRD%s %s, %s, [%s, #%s%d]%s", cond, regname[rt], regname[rt + 1], regname[rn], (u ? "" : "-"), imm8, (w ? "!" : ""));
-	} else if (((opcode & 0x0FF00000) == 0x01500000) || ((opcode & 0x0FF00090) == 0x01500010)) {
+	} else if (((opcode & 0x0FF00010) == 0x01500000) || ((opcode & 0x0FF00090) == 0x01500010)) {
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		uint8_t shift = ((opcode >> 4) & 0xFF);
 		
 		sprintf(ret, "CMP%s %s, %s%s", cond, regname[rn], regname[rm], print_shift(shift, 1));
-	} else if (((opcode & 0x0FF00000) == 0x01700000) || ((opcode & 0x0FF00090) == 0x01700010)) {
+	} else if (((opcode & 0x0FF00010) == 0x01700000) || ((opcode & 0x0FF00090) == 0x01700010)) {
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
@@ -3672,7 +3672,7 @@ const char* arm_print(uint32_t opcode) {
 		uint8_t imm8 = (((opcode >> 8) & 0xF) << 4) | ((opcode >> 0) & 0xF);
 		
 		sprintf(ret, "LDRSH%s %s, [%s, #%s%d]%s", cond, regname[rt], regname[rn], (u ? "" : "-"), imm8, (w ? "!" : ""));
-	} else if (((opcode & 0x0FE00000) == 0x01800000) || ((opcode & 0x0FE00090) == 0x01800010)) {
+	} else if (((opcode & 0x0FE00010) == 0x01800000) || ((opcode & 0x0FE00090) == 0x01800010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3785,7 +3785,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		
 		sprintf(ret, "LDREXD%s %s, %s, [%s]", cond, regname[rt], regname[rt + 1], regname[rn]);
-	} else if (((opcode & 0x0FE00000) == 0x01C00000) || ((opcode & 0x0FE00090) == 0x01C00010)) {
+	} else if (((opcode & 0x0FE00010) == 0x01C00000) || ((opcode & 0x0FE00090) == 0x01C00010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -3807,7 +3807,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		
 		sprintf(ret, "LDREXB%s %s, [%s]", cond, regname[rt], regname[rn]);
-	} else if (((opcode & 0x0FE00000) == 0x01E00000) || ((opcode & 0x0FE00090) == 0x01E00010)) {
+	} else if (((opcode & 0x0FE00010) == 0x01E00000) || ((opcode & 0x0FE00090) == 0x01E00010)) {
 		int s = (opcode >> 20) & 1;
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
@@ -4119,7 +4119,7 @@ const char* arm_print(uint32_t opcode) {
 		int rd = (opcode >> 12) & 0xF;
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "PKHBT%s %s, %s, %s%s", cond, regname[rd], regname[rn], regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0FF00070) == 0x06800050) {
@@ -4127,7 +4127,7 @@ const char* arm_print(uint32_t opcode) {
 		int rd = (opcode >> 12) & 0xF;
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "PKHTB%s %s, %s, %s%s", cond, regname[rd], regname[rn], regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0FFF00F0) == 0x068F0070) {
@@ -4158,7 +4158,7 @@ const char* arm_print(uint32_t opcode) {
 		int rd = (opcode >> 12) & 0xF;
 		int rn = (opcode >> 0) & 0xF;
 		uint8_t imm = ((opcode >> 16) & 0x1F) + 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "SSAT%s %s, #%d, %s%s", cond, regname[rd], imm, regname[rn], print_shift(shift, 1));
 	} else if ((opcode & 0x0FF000F0) == 0x06A00030) {
@@ -4254,7 +4254,7 @@ const char* arm_print(uint32_t opcode) {
 		int rd = (opcode >> 12) & 0xF;
 		int rn = (opcode >> 0) & 0xF;
 		uint8_t imm = ((opcode >> 16) & 0x1F) + 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "USAT%s %s, #%d, %s%s", cond, regname[rd], imm, regname[rn], print_shift(shift, 1));
 	} else if ((opcode & 0x0FF000F0) == 0x06E00030) {
@@ -4322,7 +4322,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "STR%s %s, [%s], %s%s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0F700010) == 0x06100000) {
@@ -4331,7 +4331,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "LDR%s %s, [%s], %s%s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0F700010) == 0x06200000) {
@@ -4340,7 +4340,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "STRT%s %s, [%s], %s%s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0F700010) == 0x06300000) {
@@ -4349,7 +4349,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "LDRT%s %s, [%s], %s%s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0F700010) == 0x06400000) {
@@ -4358,7 +4358,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "STRB%s %s, [%s], %s%s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0F700010) == 0x06500000) {
@@ -4367,7 +4367,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "LDRB%s %s, [%s], %s%s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0F700010) == 0x06600000) {
@@ -4376,7 +4376,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "STRBT%s %s, [%s], %s%s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0F700010) == 0x06700000) {
@@ -4385,7 +4385,7 @@ const char* arm_print(uint32_t opcode) {
 		int rn = (opcode >> 16) & 0xF;
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "LDRBT%s %s, [%s], %s%s%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1));
 	} else if ((opcode & 0x0F500010) == 0x07000000) {
@@ -4395,7 +4395,7 @@ const char* arm_print(uint32_t opcode) {
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
 		int w = (opcode >> 21) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "STR%s %s, [%s, %s%s%s]%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1), (w ? "!" : ""));
 	} else if ((opcode & 0x0F500010) == 0x07100000) {
@@ -4405,7 +4405,7 @@ const char* arm_print(uint32_t opcode) {
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
 		int w = (opcode >> 21) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "LDR%s %s, [%s, %s%s%s]%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1), (w ? "!" : ""));
 	} else if ((opcode & 0x0F500010) == 0x07400000) {
@@ -4415,7 +4415,7 @@ const char* arm_print(uint32_t opcode) {
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
 		int w = (opcode >> 21) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "STRB%s %s, [%s, %s%s%s]%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1), (w ? "!" : ""));
 	} else if ((opcode & 0x0F500010) == 0x07500000) {
@@ -4425,7 +4425,7 @@ const char* arm_print(uint32_t opcode) {
 		int rm = (opcode >> 0) & 0xF;
 		int u = (opcode >> 23) & 1;
 		int w = (opcode >> 21) & 1;
-		uint8_t shift = ((opcode >> 4) & 0xFF) | 0x01;
+		uint8_t shift = ((opcode >> 4) & 0xFE);
 		
 		sprintf(ret, "LDRB%s %s, [%s, %s%s%s]%s", cond, regname[rt], regname[rn], (u ? "" : "-"), regname[rm], print_shift(shift, 1), (w ? "!" : ""));
 	} else if ((opcode & 0x0FF0F0F0) == 0x0780F010) {


### PR DESCRIPTION
This PR fixes all `ARMS` instructions in the printer generator (fixes `e0060691`, for instance; before: `AND r0, r6, r1, lsl r6`; after: `MUL r6, r1, r6`).