### PR TITLE
Update CMakeLissts.txt to copy libstdc++.so.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,7 @@ if(NOT _x86 AND NOT _x86_64)
     RUNTIME DESTINATION bin)
   install(FILES ${CMAKE_SOURCE_DIR}/system/box86.conf DESTINATION /etc/binfmt.d/)
   install(FILES ${CMAKE_SOURCE_DIR}/x86lib/libstdc++.so.6 DESTINATION /usr/lib/i386-linux-gnu/)
+  install(FILES ${CMAKE_SOURCE_DIR}/x86lib/libstdc++.so.5 DESTINATION /usr/lib/i386-linux-gnu/)
   install(FILES ${CMAKE_SOURCE_DIR}/x86lib/libgcc_s.so.1 DESTINATION /usr/lib/i386-linux-gnu/)
 endif()
 


### PR DESCRIPTION
libstdc++.so.5 is Included in x86libs but not copied to /usr/lib/i386-linux-gnu when 'make install'ing.