### PR TITLE
Fix compliation of non-dynarec build

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -16,8 +16,8 @@
 #include <time.h>
 #include <limits.h>
 #include <errno.h>
-#ifdef DYNAREC
 #include <unistd.h>
+#ifdef DYNAREC
 #ifdef ARM
 #include <linux/auxvec.h>
 #include <asm/hwcap.h>


### PR DESCRIPTION
sysconf() is part of unistd.h, and src/main.c uses it. However, this
source code file only includes <unistd.h> when DYNAREC, makes
non-dynarec build fail for missing _SC_PAGESIZE macro.

Move the inclusion of <unistd.h> out of #ifdef DYNAREC.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>