### PR TITLE
wrap g_utf8_skip in glib, which is a pointer to an array of char

### DIFF
--- a/src/wrapped/wrappedglib2_private.h
+++ b/src/wrapped/wrappedglib2_private.h
@@ -1605,4 +1605,5 @@ GO(g_warn_message, vFppipp)
 //GO(_init, 
 
 DATA(g_ascii_table, 4)
+DATA(g_utf8_skip, 4)
 //GLOB(g_threads_got_initialized, 4)


### PR DESCRIPTION
Signed-off-by: Icenowy Zheng <icenowy@aosc.io>