### PR TITLE
prepending LD_LIBRARY_PATH

### DIFF
--- a/src/include/pathcoll.h
+++ b/src/include/pathcoll.h
@@ -17,6 +17,7 @@ void CopyCollection(path_collection_t* to, path_collection_t* from);
 void AddPath(const char* path, path_collection_t* collection, int folder);
 void PrependPath(const char* path, path_collection_t* collection, int folder);
 void AppendList(path_collection_t* collection, const char* List, int folder);
+void PrependList(path_collection_t* collection, const char* List, int folder);
 int FindInCollection(const char* path, path_collection_t* collection);
 
 #endif //__PATHCOLL_H_

--- a/src/main.c
+++ b/src/main.c
@@ -480,7 +480,7 @@ void LoadEnvVars(box86context_t *context)
     if(FileExist("/usr/lib32", 0))
         AddPath("/usr/lib32", &context->box86_ld_lib, 1);
     if(getenv("LD_LIBRARY_PATH"))
-        AppendList(&context->box86_ld_lib, getenv("LD_LIBRARY_PATH"), 1);   // in case some of the path are for x86 world
+        PrependList(&context->box86_ld_lib, getenv("LD_LIBRARY_PATH"), 1);   // in case some of the path are for x86 world
     if(getenv("BOX86_EMULATED_LIBS")) {
         char* p = getenv("BOX86_EMULATED_LIBS");
         ParseList(p, &context->box86_emulated_libs, 0);

--- a/src/tools/pathcoll.c
+++ b/src/tools/pathcoll.c
@@ -143,6 +143,34 @@ void AppendList(path_collection_t* collection, const char* List, int folder)
     }
 
 }
+void PrependList(path_collection_t* collection, const char* List, int folder)
+{
+    if(!List)
+        return;
+        // and now split the paths...
+    char tmp[MAX_PATH];
+    char *p = strdup(List);
+    while(p) {
+        char *p2 = strrchr(p, ':');
+        if(!p2) {
+            strncpy(tmp, p, MAX_PATH - 1);
+            p=NULL;
+        } else {
+            strncpy(tmp, p2+1, PATH_MAX);
+            tmp[PATH_MAX-1]='\0';
+            *p2 = '\0';
+        }
+        // check if there is terminal '/', add it if not
+        int l = strlen(tmp);
+        // skip empty strings
+        if(l) {
+            if(folder && tmp[l-1]!='/')
+                strcat(tmp, "/");
+            PrependPath(tmp, collection, folder);
+        }
+    }
+
+}
 
 int FindInCollection(const char* path, path_collection_t* collection)
 {


### PR DESCRIPTION
LD_LIBRARY_PATH should be able to override system libraries, this is the
behavior of ld-linux.so.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>