### PR TITLE
dynablock: do not access value when foreach on marks

### DIFF
--- a/src/dynarec/dynablock.c
+++ b/src/dynarec/dynablock.c
@@ -68,14 +68,19 @@ void FreeDynablock(dynablock_t* db)
             if(addr>=startdb && addr<enddb)
                 db->parent->direct[addr-startdb] = NULL;
         }
+       // remove from hash if there
+        khint_t kdb;
+        kdb = kh_get(dynablocks, db->parent->blocks, (uintptr_t) db->x86_addr - db->parent->base);
+        if(kdb!=kh_end(db->parent->blocks))
+            kh_del(dynablocks, db->parent->blocks, kdb);
+
         if(db->marks) {
             // Follow mark and set arm_linker instead
             khint_t k;
             char s;
-            kh_foreach(db->marks, k, s, 
+            kh_foreach_key(db->marks, k,
                 void** p = (void**)(uintptr_t)k;
                 dynarec_log(LOG_DEBUG, " -- resettable(%p)\n", p);
-                (void)s;
                 resettable(p);
             );
             // free mark
@@ -156,9 +161,8 @@ void MarkDynablock(dynablock_t* db)
             // Follow mark and set arm_linker instead
             khint_t k;
             char s;
-            kh_foreach(db->marks, k, s, 
+            kh_foreach_key(db->marks, k,
                 void** p = (void**)(uintptr_t)k;
-                (void)s;
                 resettable(p);
             );
             // free mark

--- a/src/include/khash.h
+++ b/src/include/khash.h
@@ -553,6 +553,19 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key)
 	} }
 
 /*! @function
+  @abstract     Iterate over the entries in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  kvar  Variable to which key will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach_key(h, kvar, code) { khint_t __i;           \
+       for (__i = kh_begin(h); __i != kh_end(h); ++__i) {              \
+               if (!kh_exist(h,__i)) continue;                                         \
+               (kvar) = kh_key(h,__i);                                                         \
+               code;                                                                                           \
+       } }
+
+/*! @function
   @abstract     Iterate over the values in the hash table
   @param  h     Pointer to the hash table [khash_t(name)*]
   @param  vvar  Variable to which value will be assigned


### PR DESCRIPTION
Accessing the value of a kh_set (which has no values set) is an
undefined behavior, which may make monsters to appear.

Add a kh_foreach_key macro that do not touch values at all, and use it
when ennuerating marks in dynablock, to prevent SIGSEGV of accessing
non-existent values.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>