### PR TITLE
Make test10 more robust

### DIFF
--- a/runTest.cmake
+++ b/runTest.cmake
@@ -13,7 +13,14 @@ if( NOT TEST_REFERENCE )
 endif( NOT TEST_REFERENCE )
 
 set(ENV{BOX86_LOG} 0)
-set(ENV{LD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/x86lib)
+if( EXISTS ${CMAKE_SOURCE_DIR}/x86lib )
+  # we are inside box86 folder
+  set(ENV{LD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/x86lib)
+else()
+  # we are inside build folder
+  set(ENV{LD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/../x86lib)
+endif( EXISTS ${CMAKE_SOURCE_DIR}/x86lib )
+
 # run the test program, capture the stdout/stderr and the result var
 execute_process(
   COMMAND ${TEST_PROGRAM} ${TEST_ARGS} ${TEST_ARGS2}


### PR DESCRIPTION
Test10 currently only passes after "make install" (no regard to x86lib directory needed) or we build directly inside box86 folder.
This change make sure x86lib folder is properly located so that we can also "ctest" inside build folder after compile without "make install".