### PR TITLE
[DYNAREC] Fixed the four VMOV VFPU instructions printer

### DIFF
--- a/src/dynarec/arm_instructions.txt
+++ b/src/dynarec/arm_instructions.txt
@@ -523,6 +523,12 @@ ARM_ cond 1 0 0 1 1 0 W 1 Rn register_list LDMIB<c> <Rn>{!}, <registers>
 ARM_ cond 1 0 1 0 imm24 B<c> <label>
 ARM_ cond 1 0 1 1 imm24 BL<c> <label>
 
+VFPU cond 1 1 0 0 0 1 0 0 Rn Rt 1 0 1 0 0 0 M 1 Vm VMOV<c> <Sm>, <Sm1>, <Rt>, <Rn>
+VFPU cond 1 1 0 0 0 1 0 1 Rn Rt 1 0 1 0 0 0 M 1 Vm VMOV<c> <Rt>, <Rn>, <Sm>, <Sm1>
+VFPU cond 1 1 0 0 0 1 0 0 Rn Rt 1 0 1 1 0 0 M 1 Vm VMOV<c> <Dm>, <Rt>, <Rn>
+VFPU cond 1 1 0 0 0 1 0 1 Rn Rt 1 0 1 1 0 0 M 1 Vm VMOV<c> <Rt>, <Rn>, <Dm>
+;INVALIDATE <4> 1 1 0 0 0 1 0 <9> 1 0 1 <9>
+
 INVALIDATE <4> 1 1 0 0 0 <11> 1 0 1 <9>
 INVALIDATE <4> 1 1 0 0 0 <11> 1 0 1 <9>
 INVALIDATE <4> 1 1 0 1 1 <1> 1 <9> 1 0 1 <9>
@@ -553,12 +559,6 @@ VFPU cond 1 1 1 0 0 0 0 1 Vn Rt 1 0 1 0 N (0) (0) 1 (0) (0) (0) (0) VMOV<c> <Rt>
 VFPU cond 1 1 1 0 1 1 1 1 0 0 0 1 Rt 1 0 1 0 (0) (0) (0) 1 (0) (0) (0) (0) VMRS<c> <Rt>, FPSCR
 VFPU cond 1 1 1 0 U @<2> 1 Vn Rt 1 0 1 1 N @<2> 1 (0) (0) (0) (0) @ set uint8_t opc = (u << 3) + (param1_2 << 2) + param2_2@ = uint8_t shift, size @@ (opc & 0b01000) == 0b01000@ @@ (opc & 0b01001) == 0b00001@ @@ (opc & 0b11011) == 0b00000@ shift,0,1,2,0xFF;size,0,1,2,4@ set uint8_t decodedImm = (opc & 0x7) >> shift@ @ VMOV<c>.<dt> <Rt>, <Dn[x]>
 INVALIDATE <4> 1 1 1 0 <12> 1 0 1 <4> 1 <4>
-
-VFPU cond 1 1 0 0 0 1 0 0 Rn Rt 1 0 1 0 0 0 M 1 Vm VMOV<c> <Sm>, <Sm1>, <Rt>, <Rn>
-VFPU cond 1 1 0 0 0 1 0 1 Rn Rt 1 0 1 0 0 0 M 1 Vm VMOV<c> <Rt>, <Rn>, <Sm>, <Sm1>
-VFPU cond 1 1 0 0 0 1 0 0 Rn Rt 1 0 1 1 0 0 M 1 Vm VMOV<c> <Dm>, <Rt>, <Rn>
-VFPU cond 1 1 0 0 0 1 0 1 Rn Rt 1 0 1 1 0 0 M 1 Vm VMOV<c> <Rt>, <Rn>, <Dm>
-INVALIDATE <4> 1 1 0 0 0 1 0 <9> 1 0 1 <9>
 
 VFPU cond 1 1 1 0 0 D 0 0 Vn Vd 1 0 1 sz N op M 0 Vm VML\(op ? "S" : "A")\<c>.F\(size ? "64" : "32")\ <Dd>, <Dn>, <Dm>
 VFPU cond 1 1 1 0 0 D 0 1 Vn Vd 1 0 1 sz N op M 0 Vm VNML\(op ? "S" : "A")\<c>.F\(size ? "64" : "32")\ <Dd>, <Dn>, <Dm>

--- a/src/dynarec/arm_printer.c
+++ b/src/dynarec/arm_printer.c
@@ -4610,6 +4610,34 @@ const char* arm_print(uint32_t opcode) {
 		uint32_t imm24 = ((opcode >> 0) & 0xFFFFFF);
 		
 		sprintf(ret, "BL%s %+d", cond, (imm24 & 0x800000 ? imm24 | 0xFF000000 : imm24) + 2);
+	} else if ((opcode & 0x0FF00FD0) == 0x0C400A10) {
+		const char* cond = conds[(opcode >> 28) & 0xF];
+		int rt = (opcode >> 12) & 0xF;
+		int rn = (opcode >> 16) & 0xF;
+		int m = ((opcode >> 5) & 1) << 4 | ((opcode >> 0) & 0xF);
+		
+		sprintf(ret, "VMOV%s %s, %s, %s, %s", cond, vecname[m], vecname[m + 1], regname[rt], regname[rn]);
+	} else if ((opcode & 0x0FF00FD0) == 0x0C500A10) {
+		const char* cond = conds[(opcode >> 28) & 0xF];
+		int rt = (opcode >> 12) & 0xF;
+		int rn = (opcode >> 16) & 0xF;
+		int m = ((opcode >> 5) & 1) << 4 | ((opcode >> 0) & 0xF);
+		
+		sprintf(ret, "VMOV%s %s, %s, %s, %s", cond, regname[rt], regname[rn], vecname[m], vecname[m + 1]);
+	} else if ((opcode & 0x0FF00FD0) == 0x0C400B10) {
+		const char* cond = conds[(opcode >> 28) & 0xF];
+		int rt = (opcode >> 12) & 0xF;
+		int rn = (opcode >> 16) & 0xF;
+		int m = ((opcode >> 5) & 1) << 4 | ((opcode >> 0) & 0xF);
+		
+		sprintf(ret, "VMOV%s %s, %s, %s", cond, vecname[0x20 + m], regname[rt], regname[rn]);
+	} else if ((opcode & 0x0FF00FD0) == 0x0C500B10) {
+		const char* cond = conds[(opcode >> 28) & 0xF];
+		int rt = (opcode >> 12) & 0xF;
+		int rn = (opcode >> 16) & 0xF;
+		int m = ((opcode >> 5) & 1) << 4 | ((opcode >> 0) & 0xF);
+		
+		sprintf(ret, "VMOV%s %s, %s, %s", cond, regname[rt], regname[rn], vecname[0x20 + m]);
 	} else if ((opcode & 0x0F800E00) == 0x0C000A00) {
 		strcpy(ret, "???");
 	} else if ((opcode & 0x0F800E00) == 0x0C000A00) {
@@ -4817,36 +4845,6 @@ const char* arm_print(uint32_t opcode) {
 		
 		sprintf(ret, "VMOV%s.%s %s, %s[%d]", cond, dts[(u << 2) + size], regname[rt], vecname[0x20 + n], decodedImm);
 	} else if ((opcode & 0x0F000E10) == 0x0E000A10) {
-		strcpy(ret, "???");
-	} else if ((opcode & 0x0FF00FD0) == 0x0C400A10) {
-		const char* cond = conds[(opcode >> 28) & 0xF];
-		int rt = (opcode >> 12) & 0xF;
-		int rn = (opcode >> 16) & 0xF;
-		int m = ((opcode >> 5) & 1) << 4 | ((opcode >> 0) & 0xF);
-		
-		sprintf(ret, "VMOV%s %s, %s, %s, %s", cond, vecname[m], vecname[m + 1], regname[rt], regname[rn]);
-	} else if ((opcode & 0x0FF00FD0) == 0x0C500A10) {
-		const char* cond = conds[(opcode >> 28) & 0xF];
-		int rt = (opcode >> 12) & 0xF;
-		int rn = (opcode >> 16) & 0xF;
-		int m = ((opcode >> 5) & 1) << 4 | ((opcode >> 0) & 0xF);
-		
-		sprintf(ret, "VMOV%s %s, %s, %s, %s", cond, regname[rt], regname[rn], vecname[m], vecname[m + 1]);
-	} else if ((opcode & 0x0FF00FD0) == 0x0C400B10) {
-		const char* cond = conds[(opcode >> 28) & 0xF];
-		int rt = (opcode >> 12) & 0xF;
-		int rn = (opcode >> 16) & 0xF;
-		int m = ((opcode >> 5) & 1) << 4 | ((opcode >> 0) & 0xF);
-		
-		sprintf(ret, "VMOV%s %s, %s, %s", cond, vecname[0x20 + m], regname[rt], regname[rn]);
-	} else if ((opcode & 0x0FF00FD0) == 0x0C500B10) {
-		const char* cond = conds[(opcode >> 28) & 0xF];
-		int rt = (opcode >> 12) & 0xF;
-		int rn = (opcode >> 16) & 0xF;
-		int m = ((opcode >> 5) & 1) << 4 | ((opcode >> 0) & 0xF);
-		
-		sprintf(ret, "VMOV%s %s, %s, %s", cond, regname[rt], regname[rn], vecname[0x20 + m]);
-	} else if ((opcode & 0x0FE00E00) == 0x0C400A00) {
 		strcpy(ret, "???");
 	} else if ((opcode & 0x0FB00E10) == 0x0E000A00) {
 		const char* cond = conds[(opcode >> 28) & 0xF];

--- a/src/dynarec/last_run.txt
+++ b/src/dynarec/last_run.txt
@@ -415,6 +415,10 @@ ARM_ cond 1 0 0 1 1 0 W 1 Rn/=1101 register_list LDMFA<c> <Rn>{!}, <registers>
 ARM_ cond 1 0 0 1 1 0 W 1 Rn register_list LDMIB<c> <Rn>{!}, <registers>
 ARM_ cond 1 0 1 0 imm24 B<c> <label>
 ARM_ cond 1 0 1 1 imm24 BL<c> <label>
+VFPU cond 1 1 0 0 0 1 0 0 Rn Rt 1 0 1 0 0 0 M 1 Vm VMOV<c> <Sm>, <Sm1>, <Rt>, <Rn>
+VFPU cond 1 1 0 0 0 1 0 1 Rn Rt 1 0 1 0 0 0 M 1 Vm VMOV<c> <Rt>, <Rn>, <Sm>, <Sm1>
+VFPU cond 1 1 0 0 0 1 0 0 Rn Rt 1 0 1 1 0 0 M 1 Vm VMOV<c> <Dm>, <Rt>, <Rn>
+VFPU cond 1 1 0 0 0 1 0 1 Rn Rt 1 0 1 1 0 0 M 1 Vm VMOV<c> <Rt>, <Rn>, <Dm>
 INVALIDATE <4> 1 1 0 0 0 <11> 1 0 1 <9>
 INVALIDATE <4> 1 1 0 0 0 <11> 1 0 1 <9>
 INVALIDATE <4> 1 1 0 1 1 <1> 1 <9> 1 0 1 <9>
@@ -443,11 +447,6 @@ VFPU cond 1 1 1 0 0 0 0 1 Vn Rt 1 0 1 0 N (0) (0) 1 (0) (0) (0) (0) VMOV<c> <Rt>
 VFPU cond 1 1 1 0 1 1 1 1 0 0 0 1 Rt 1 0 1 0 (0) (0) (0) 1 (0) (0) (0) (0) VMRS<c> <Rt>, FPSCR
 VFPU cond 1 1 1 0 U @<2> 1 Vn Rt 1 0 1 1 N @<2> 1 (0) (0) (0) (0) @ set uint8_t opc = (u << 3) + (param1_2 << 2) + param2_2@ = uint8_t shift, size @@ (opc & 0b01000) == 0b01000@ @@ (opc & 0b01001) == 0b00001@ @@ (opc & 0b11011) == 0b00000@ shift,0,1,2,0xFF;size,0,1,2,4@ set uint8_t decodedImm = (opc & 0x7) >> shift@ @ VMOV<c>.<dt> <Rt>, <Dn[x]>
 INVALIDATE <4> 1 1 1 0 <12> 1 0 1 <4> 1 <4>
-VFPU cond 1 1 0 0 0 1 0 0 Rn Rt 1 0 1 0 0 0 M 1 Vm VMOV<c> <Sm>, <Sm1>, <Rt>, <Rn>
-VFPU cond 1 1 0 0 0 1 0 1 Rn Rt 1 0 1 0 0 0 M 1 Vm VMOV<c> <Rt>, <Rn>, <Sm>, <Sm1>
-VFPU cond 1 1 0 0 0 1 0 0 Rn Rt 1 0 1 1 0 0 M 1 Vm VMOV<c> <Dm>, <Rt>, <Rn>
-VFPU cond 1 1 0 0 0 1 0 1 Rn Rt 1 0 1 1 0 0 M 1 Vm VMOV<c> <Rt>, <Rn>, <Dm>
-INVALIDATE <4> 1 1 0 0 0 1 0 <9> 1 0 1 <9>
 VFPU cond 1 1 1 0 0 D 0 0 Vn Vd 1 0 1 sz N op M 0 Vm VML\(op ? "S" : "A")\<c>.F\(size ? "64" : "32")\ <Dd>, <Dn>, <Dm>
 VFPU cond 1 1 1 0 0 D 0 1 Vn Vd 1 0 1 sz N op M 0 Vm VNML\(op ? "S" : "A")\<c>.F\(size ? "64" : "32")\ <Dd>, <Dn>, <Dm>
 VFPU cond 1 1 1 0 0 D 1 0 Vn Vd 1 0 1 sz N 0 M 0 Vm VMUL<c>.F\(size ? "64" : "32")\ <Dd>, <Dn>, <Dm>


### PR DESCRIPTION
This PR moves the VFPU `VMOV` instruction above an `INVALIDATE` instruction to the ARM opcodes printer generator (fixes a `???` shown in https://github.com/ptitSeb/box86/issues/167#issuecomment-668860278).