### PR TITLE
[DYNAREC] Fixed the UBFX and others instructions

### DIFF
--- a/rebuild_printer.py
+++ b/rebuild_printer.py
@@ -575,11 +575,11 @@ def main(root, ver, __debug_forceAllDebugging=False):
 					append("int rot = (opcode >> " + str(variables["r"]) + ") & 3;\nchar tmprot[8] = {0};\n")
 					append("if (rot) {\nsprintf(tmprot, \" ror %d\", rot * 8);\n}\n")
 				if variables["sb"][0] != -1:
-					append("int lsb = (opcode >> " + str(variables["sb"][0]) + ") & 0xF;\n")
+					append("int lsb = (opcode >> " + str(variables["sb"][0]) + ") & 0x1F;\n")
 				if variables["sb"][1] != -1:
-					append("int msb = (opcode >> " + str(variables["sb"][1]) + ") & 0xF;\n")
+					append("int msb = (opcode >> " + str(variables["sb"][1]) + ") & 0x1F;\n")
 				if variables["sb"][2] != -1:
-					append("int widthm1 = (opcode >> " + str(variables["sb"][2]) + ") & 0xF;\n")
+					append("int widthm1 = (opcode >> " + str(variables["sb"][2]) + ") & 0x1F;\n")
 				if variables["reglist16"] != -1:
 					append("int reglist = (opcode >> " + str(variables["reglist16"]) + ") & 0xFFFF;\n")
 				if imms != []:

--- a/src/dynarec/arm_printer.c
+++ b/src/dynarec/arm_printer.c
@@ -4446,24 +4446,24 @@ const char* arm_print(uint32_t opcode) {
 	} else if ((opcode & 0x0FE0007F) == 0x07C0001F) {
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
-		int lsb = (opcode >> 7) & 0xF;
-		int msb = (opcode >> 16) & 0xF;
+		int lsb = (opcode >> 7) & 0x1F;
+		int msb = (opcode >> 16) & 0x1F;
 		
 		sprintf(ret, "BFC%s %s, #%d, #%d", cond, regname[rd], lsb, msb - lsb + 1);
 	} else if ((opcode & 0x0FE00070) == 0x07C00010) {
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
 		int rn = (opcode >> 0) & 0xF;
-		int lsb = (opcode >> 7) & 0xF;
-		int msb = (opcode >> 16) & 0xF;
+		int lsb = (opcode >> 7) & 0x1F;
+		int msb = (opcode >> 16) & 0x1F;
 		
 		sprintf(ret, "BFI%s %s, %s, #%d, #%d", cond, regname[rd], regname[rn], lsb, msb - lsb + 1);
 	} else if ((opcode & 0x0FE00070) == 0x07E00050) {
 		const char* cond = conds[(opcode >> 28) & 0xF];
 		int rd = (opcode >> 12) & 0xF;
 		int rn = (opcode >> 0) & 0xF;
-		int lsb = (opcode >> 7) & 0xF;
-		int widthm1 = (opcode >> 16) & 0xF;
+		int lsb = (opcode >> 7) & 0x1F;
+		int widthm1 = (opcode >> 16) & 0x1F;
 		
 		sprintf(ret, "UBFX%s %s, %s, #%d, #%d", cond, regname[rd], regname[rn], lsb, widthm1 + 1);
 	} else if ((opcode & 0x0FDF0000) == 0x080D0000) {


### PR DESCRIPTION
This PR fixes all instructions containing a LSB, MSB or widthm1 bit range in the printer (includes the BFC, BFI and UBFX instructions).