### PR TITLE
Optimize compilation & full install commands

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -16,7 +16,14 @@ Compiling
 
   _a build for model 2, 3 and 4 can be done. Model 1 and 0 cannot (at least not with Dynarec, as they lack NEON support)_
  
-`mkdir build; cd build; cmake .. -DRPI4=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo; make`
+```
+git clone https://github.com/ptitSeb/box86
+cd box86
+mkdir build; cd build; cmake .. -DRPI4=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+make -j24
+sudo make install
+sudo systemctl restart systemd-binfmt
+```
  
   _For Pi4. Change to RPI2 or RPI3 for other models._
 


### PR DESCRIPTION
Here is all the commands it takes to compile & install box86 on a Raspberry Pi.
Using `make -j24` is much faster - it compiles in about 1/6 of the time as it does originally.