### PR TITLE
Fix presumable typo in wrappedlibncurses files

### DIFF
--- a/src/wrapped/wrappedlibncurses.c
+++ b/src/wrapped/wrappedlibncurses.c
@@ -82,7 +82,7 @@ EXPORT int my_printw(x86emu_t* emu, void* fmt, void* b)
     myStackAlign((const char*)fmt, b, emu->scratch);
     return my->vwprintw(my->stdscr, fmt, emu->scratch);
     #else
-    return my->vmprintw(my->stdscr, fmt, b);
+    return my->vwprintw(my->stdscr, fmt, b);
     #endif
 }
 

--- a/src/wrapped/wrappedlibncurses6.c
+++ b/src/wrapped/wrappedlibncurses6.c
@@ -82,7 +82,7 @@ EXPORT int my6_printw(x86emu_t* emu, void* fmt, void* b)
     myStackAlign((const char*)fmt, b, emu->scratch);
     return my->vwprintw(my->stdscr, fmt, emu->scratch);
     #else
-    return my->vmprintw(my->stdscr, fmt, b);
+    return my->vwprintw(my->stdscr, fmt, b);
     #endif
 }
 

--- a/src/wrapped/wrappedlibncursesw.c
+++ b/src/wrapped/wrappedlibncursesw.c
@@ -80,7 +80,7 @@ EXPORT int myw_printw(x86emu_t* emu, void* fmt, void* b)
     myStackAlign((const char*)fmt, b, emu->scratch);
     return my->vwprintw(my->stdscr, fmt, emu->scratch);
     #else
-    return my->vmprintw(my->stdscr, fmt, b);
+    return my->vwprintw(my->stdscr, fmt, b);
     #endif
 }
 


### PR DESCRIPTION
A call to vmprintw is made, which is a non-existent function.
Presumably, vwprintw is meant to be called instead.