### PR TITLE
Create a fake IDirect3D9 object instead of changing the vtable

### DIFF
--- a/src/wrapped/wrappedd3dadapter9_gen.h
+++ b/src/wrapped/wrappedd3dadapter9_gen.h
@@ -189,7 +189,7 @@ static void make_vtable_IDirect3DDevice9Vtbl(x86emu_t* emu, IDirect3DDevice9Vtbl
     GO(TestCooperativeLevel, iFp, 1);
     GO(GetAvailableTextureMem, uFp, 1);
     GO(EvictManagedResources, iFp, 1);
-    GO(GetDirect3D, iFpp, 2);
+    GOM(GetDirect3D, iFEpp, 2);
     GO(GetDeviceCaps, iFpp, 2);
     GO(GetDisplayMode, iFpup, 3);
     GO(GetCreationParameters, iFpp, 2);


### PR DESCRIPTION
This means both x86 and ARM code can have the right function pointers
at the same time, allowing a hack in Gallium Nine to be removed.
