### PR TITLE
Fixed INC/DEC (for lazy flags)

### DIFF
--- a/src/emu/x86primop.h
+++ b/src/emu/x86primop.h
@@ -97,6 +97,7 @@ Implements the DEC instruction and side effects.
 ****************************************************************************/
 static inline uint8_t dec8(x86emu_t *emu, uint8_t d)
 {
+    CHECK_FLAGS(emu);
     emu->res = d - 1;
 	emu->op1 = d;
 	emu->df = d_dec8;
@@ -109,6 +110,7 @@ Implements the DEC instruction and side effects.
 ****************************************************************************/
 static inline uint16_t dec16(x86emu_t *emu, uint16_t d)
 {
+    CHECK_FLAGS(emu);
     emu->res = d - 1;
 	emu->op1 = d;
 	emu->df = d_dec16;
@@ -122,6 +124,7 @@ Implements the DEC instruction and side effects.
 ****************************************************************************/
 static inline uint32_t dec32(x86emu_t *emu, uint32_t d)
 {
+    CHECK_FLAGS(emu);
     emu->res = d - 1;
 	emu->op1 = d;
 	emu->df = d_dec32;
@@ -135,6 +138,7 @@ Implements the INC instruction and side effects.
 ****************************************************************************/
 static inline uint8_t inc8(x86emu_t *emu, uint8_t d)
 {
+    CHECK_FLAGS(emu);
 	emu->res = d + 1;
 	emu->op1 = d;
 	emu->df = d_inc8;
@@ -147,6 +151,7 @@ Implements the INC instruction and side effects.
 ****************************************************************************/
 static inline uint16_t inc16(x86emu_t *emu, uint16_t d)
 {
+    CHECK_FLAGS(emu);
 	emu->res = d + 1;
 	emu->op1 = d;
 	emu->df = d_inc16;
@@ -159,6 +164,7 @@ Implements the INC instruction and side effects.
 ****************************************************************************/
 static inline uint32_t inc32(x86emu_t *emu, uint32_t d)
 {
+    CHECK_FLAGS(emu);
 	if(emu->df == d_shr32) {
 		// workaround for some wine trickery
 		uint32_t cnt = emu->op2;


### PR DESCRIPTION
```c
// gcc box86_test.c -o box86_test
#include <stdio.h>

__attribute__((naked)) int foo()
{
  __asm(
    "movl $0xFFFFFFFF, %eax\n\t"
    "addl $1, %eax\n\t"
    "incl %eax\n\t"
    "pushf\n\t"
    "pop  %eax\n\t"
    "ret\n\n"
    );
}

int main()
{
  printf("eflags: 0x%08x\n", foo());
  return 0;
}
```
![asm](https://user-images.githubusercontent.com/78925867/128131018-2ba08931-2a87-4621-81ee-cfb9e0a67aa5.png)


![test](https://user-images.githubusercontent.com/78925867/128131248-ecf470e2-4c5c-4ec6-adfd-77c307211556.png)


![dec](https://user-images.githubusercontent.com/78925867/128130919-3d60fae4-4804-4be9-94b8-3061347063cc.png)
![inc](https://user-images.githubusercontent.com/78925867/128130927-0e5c7352-81f1-4b0c-8d1a-42d8e63ca584.png)
