### PR TITLE
Move all _GNU_SOURCE defination to the file head

### DIFF
--- a/src/wrapped/wrappedalure.c
+++ b/src/wrapped/wrappedalure.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedalut.c
+++ b/src/wrapped/wrappedalut.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedandroidshmem.c
+++ b/src/wrapped/wrappedandroidshmem.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedappindicator.c
+++ b/src/wrapped/wrappedappindicator.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedatk.c
+++ b/src/wrapped/wrappedatk.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedatkbridge.c
+++ b/src/wrapped/wrappedatkbridge.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedbz2.c
+++ b/src/wrapped/wrappedbz2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedcairo.c
+++ b/src/wrapped/wrappedcairo.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedcrypto.c
+++ b/src/wrapped/wrappedcrypto.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedcurl.c
+++ b/src/wrapped/wrappedcurl.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedd3dadapter9.c
+++ b/src/wrapped/wrappedd3dadapter9.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappeddbus.c
+++ b/src/wrapped/wrappeddbus.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappeddbusglib1.c
+++ b/src/wrapped/wrappeddbusglib1.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappeddbusmenuglib.c
+++ b/src/wrapped/wrappeddbusmenuglib.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappeddbusmenugtk.c
+++ b/src/wrapped/wrappeddbusmenugtk.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedexpat.c
+++ b/src/wrapped/wrappedexpat.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedfontconfig.c
+++ b/src/wrapped/wrappedfontconfig.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedfreetype.c
+++ b/src/wrapped/wrappedfreetype.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgconf2.c
+++ b/src/wrapped/wrappedgconf2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgdk3.c
+++ b/src/wrapped/wrappedgdk3.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgdkpixbuf2.c
+++ b/src/wrapped/wrappedgdkpixbuf2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgdkx112.c
+++ b/src/wrapped/wrappedgdkx112.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgmodule2.c
+++ b/src/wrapped/wrappedgmodule2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgnutls.c
+++ b/src/wrapped/wrappedgnutls.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgssapikrb5.c
+++ b/src/wrapped/wrappedgssapikrb5.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgstinterfaces010.c
+++ b/src/wrapped/wrappedgstinterfaces010.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgstreamer010.c
+++ b/src/wrapped/wrappedgstreamer010.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgthread2.c
+++ b/src/wrapped/wrappedgthread2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedgudev1.c
+++ b/src/wrapped/wrappedgudev1.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappediconv.c
+++ b/src/wrapped/wrappediconv.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedkrb5.c
+++ b/src/wrapped/wrappedkrb5.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlber.c
+++ b/src/wrapped/wrappedlber.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlcms2.c
+++ b/src/wrapped/wrappedlcms2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedldapr.c
+++ b/src/wrapped/wrappedldapr.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedldlinux.c
+++ b/src/wrapped/wrappedldlinux.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibasound.c
+++ b/src/wrapped/wrappedlibasound.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 #include <stdarg.h>
 

--- a/src/wrapped/wrappedlibcrypt.c
+++ b/src/wrapped/wrappedlibcrypt.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibcups.c
+++ b/src/wrapped/wrappedlibcups.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibdrm.c
+++ b/src/wrapped/wrappedlibdrm.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibformw.c
+++ b/src/wrapped/wrappedlibformw.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibgl.c
+++ b/src/wrapped/wrappedlibgl.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibglu.c
+++ b/src/wrapped/wrappedlibglu.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibice.c
+++ b/src/wrapped/wrappedlibice.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibm.c
+++ b/src/wrapped/wrappedlibm.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 #include <complex.h>
 #include <math.h>

--- a/src/wrapped/wrappedlibogg.c
+++ b/src/wrapped/wrappedlibogg.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibresolv.c
+++ b/src/wrapped/wrappedlibresolv.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibsm.c
+++ b/src/wrapped/wrappedlibsm.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibsndfile.c
+++ b/src/wrapped/wrappedlibsndfile.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibssl.c
+++ b/src/wrapped/wrappedlibssl.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibtiff.c
+++ b/src/wrapped/wrappedlibtiff.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibusb1.c
+++ b/src/wrapped/wrappedlibusb1.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibuuid.c
+++ b/src/wrapped/wrappedlibuuid.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibv4l2.c
+++ b/src/wrapped/wrappedlibv4l2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibvorbis.c
+++ b/src/wrapped/wrappedlibvorbis.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibx11.c
+++ b/src/wrapped/wrappedlibx11.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibx11xcb.c
+++ b/src/wrapped/wrappedlibx11xcb.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxau.c
+++ b/src/wrapped/wrappedlibxau.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcb.c
+++ b/src/wrapped/wrappedlibxcb.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbdri2.c
+++ b/src/wrapped/wrappedlibxcbdri2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbdri3.c
+++ b/src/wrapped/wrappedlibxcbdri3.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbimage.c
+++ b/src/wrapped/wrappedlibxcbimage.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbkeysyms.c
+++ b/src/wrapped/wrappedlibxcbkeysyms.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbpresent.c
+++ b/src/wrapped/wrappedlibxcbpresent.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbrandr.c
+++ b/src/wrapped/wrappedlibxcbrandr.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbshape.c
+++ b/src/wrapped/wrappedlibxcbshape.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbshm.c
+++ b/src/wrapped/wrappedlibxcbshm.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbxfixes.c
+++ b/src/wrapped/wrappedlibxcbxfixes.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcbxtest.c
+++ b/src/wrapped/wrappedlibxcbxtest.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcomposite.c
+++ b/src/wrapped/wrappedlibxcomposite.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxcursor.c
+++ b/src/wrapped/wrappedlibxcursor.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxdamage.c
+++ b/src/wrapped/wrappedlibxdamage.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxdmcp.c
+++ b/src/wrapped/wrappedlibxdmcp.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxext.c
+++ b/src/wrapped/wrappedlibxext.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxfixes.c
+++ b/src/wrapped/wrappedlibxfixes.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxft.c
+++ b/src/wrapped/wrappedlibxft.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxi.c
+++ b/src/wrapped/wrappedlibxi.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxmu.c
+++ b/src/wrapped/wrappedlibxmu.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxpm.c
+++ b/src/wrapped/wrappedlibxpm.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxrandr.c
+++ b/src/wrapped/wrappedlibxrandr.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxrender.c
+++ b/src/wrapped/wrappedlibxrender.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxss.c
+++ b/src/wrapped/wrappedlibxss.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxt.c
+++ b/src/wrapped/wrappedlibxt.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxtst.c
+++ b/src/wrapped/wrappedlibxtst.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibxxf86vm.c
+++ b/src/wrapped/wrappedlibxxf86vm.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedlibz.c
+++ b/src/wrapped/wrappedlibz.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappednsl.c
+++ b/src/wrapped/wrappednsl.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappednspr4.c
+++ b/src/wrapped/wrappednspr4.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappednss3.c
+++ b/src/wrapped/wrappednss3.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappednssutil3.c
+++ b/src/wrapped/wrappednssutil3.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedopenal.c
+++ b/src/wrapped/wrappedopenal.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedpango.c
+++ b/src/wrapped/wrappedpango.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedpangocairo.c
+++ b/src/wrapped/wrappedpangocairo.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedpangoft2.c
+++ b/src/wrapped/wrappedpangoft2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedplc4.c
+++ b/src/wrapped/wrappedplc4.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedplds4.c
+++ b/src/wrapped/wrappedplds4.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedpng12.c
+++ b/src/wrapped/wrappedpng12.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedpng16.c
+++ b/src/wrapped/wrappedpng16.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedpulsesimple.c
+++ b/src/wrapped/wrappedpulsesimple.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl1.c
+++ b/src/wrapped/wrappedsdl1.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl1image.c
+++ b/src/wrapped/wrappedsdl1image.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl1mixer.c
+++ b/src/wrapped/wrappedsdl1mixer.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl1net.c
+++ b/src/wrapped/wrappedsdl1net.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl1sound.c
+++ b/src/wrapped/wrappedsdl1sound.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl1ttf.c
+++ b/src/wrapped/wrappedsdl1ttf.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl2.c
+++ b/src/wrapped/wrappedsdl2.c
@@ -1,8 +1,8 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 #include <stdarg.h>
 

--- a/src/wrapped/wrappedsdl2image.c
+++ b/src/wrapped/wrappedsdl2image.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl2mixer.c
+++ b/src/wrapped/wrappedsdl2mixer.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl2net.c
+++ b/src/wrapped/wrappedsdl2net.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsdl2ttf.c
+++ b/src/wrapped/wrappedsdl2ttf.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsecret1.c
+++ b/src/wrapped/wrappedsecret1.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsmime3.c
+++ b/src/wrapped/wrappedsmime3.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsmpeg.c
+++ b/src/wrapped/wrappedsmpeg.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedsmpeg2.c
+++ b/src/wrapped/wrappedsmpeg2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedssl3.c
+++ b/src/wrapped/wrappedssl3.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedtbbmalloc.c
+++ b/src/wrapped/wrappedtbbmalloc.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedtcmallocminimal.c
+++ b/src/wrapped/wrappedtcmallocminimal.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedudev0.c
+++ b/src/wrapped/wrappedudev0.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedudev1.c
+++ b/src/wrapped/wrappedudev1.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedutil.c
+++ b/src/wrapped/wrappedutil.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedvorbisfile.c
+++ b/src/wrapped/wrappedvorbisfile.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedvulkan.c
+++ b/src/wrapped/wrappedvulkan.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedwaylandclient.c
+++ b/src/wrapped/wrappedwaylandclient.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedxinerama.c
+++ b/src/wrapped/wrappedxinerama.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedxml2.c
+++ b/src/wrapped/wrappedxml2.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"

--- a/src/wrapped/wrappedxslt.c
+++ b/src/wrapped/wrappedxslt.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#define _GNU_SOURCE         /* See feature_test_macros(7) */
 #include <dlfcn.h>
 
 #include "wrappedlibs.h"


### PR DESCRIPTION
Accroding to man 7 feature_test_macros' guide line here:
_NOTE:  In  order to be effective, a feature test macro must be defined before including any header files.  This can be done either in the compilation command
       (cc -DMACRO=value) or by defining the macro within the source code before including any headers.  The requirement that the macro must be defined  before  in‐
       cluding  any  header  file  exists  because header files may freely include one another._