### PR TITLE
Don't use cross-compile GCC on 32-bit systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,13 @@ else()
     set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE} CACHE INTERNAL "The Python3 executable" FORCE)
 endif()
 
-if(RK3399 OR RPI4ARM64 OR PHYTIUM OR SD845 OR A64)
+cmake_host_system_information(RESULT CMAKE_HOST_SYSTEM_PROCESSOR QUERY OS_PLATFORM)
+string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "i686"  _x86)
+string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "x86_64"  _x86_64)
+string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "aarch64"  _aarch64)
+string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "armhf"  _armhf)
+
+if(_aarch64 AND (RK3399 OR RPI4ARM64 OR PHYTIUM OR SD845 OR A64))
     set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
     #set(CMAKE_ASM_COMPILER arm-linux-gnueabihf-as) #will use gcc in fact
     set(CMAKE_C_COMPILER_TARGET arm-linux-gnueabihf)
@@ -592,11 +598,6 @@ else()
         target_link_options(${BOX86} PUBLIC -Wl,-Ttext-segment,${BOX86_ELF_ADDRESS})
     endif()
 endif()
-
-string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "i686"  _x86)
-string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "x86_64"  _x86_64)
-string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "aarch64"  _aarch64)
-string(COMPARE EQUAL "${CMAKE_HOST_SYSTEM_PROCESSOR}" "armhf"  _armhf)
 
 if(NOT _x86 AND NOT _x86_64)
   install(TARGETS ${BOX86}


### PR DESCRIPTION
Hi,

I was trying to compile box86 on a  on a RockPro64 in a a 32-bit (armv8l) Arch Linux chroot (the main OS is Manjaro, but I'm using a chroot because AFAIK there isn't an easy way to set up multilib/multiarch on Manjaro). 

I ran into trouble if I used `-DRK3399=1` because CMake tries to use a specific gcc binary (`arm-linux-gnueabihf-gcc`).   To get around this, I modified the CMakeFile to only override the `CMAKE_COMPILER` variable if CMake reports that it is running on `aarch64`.

I used [cmake_host_system_information](https://cmake.org/cmake/help/latest/command/cmake_host_system_information.html) for this, because the `CMAKE_HOST_SYSTEM_PROCESSOR` variable otherwise doesn't get set until after running `project()`, which seems too late.

I was thinking it might even make sense to just do `if(_aarch64) ...` instead of checking all the various flags?  If that makes sense, let me know and I can update this PR.

I've tested this by:

* running `cmake .. -DRK3399=1` in Manjaro aarch64 and verifying that CMake (for me) errors out because it can't find `arm-linux-gnueabihf-gcc`
* running `cmake .. -DRK3399=1` in my Arch Linux armv8l chroot and verifying that CMake works

PS, thanks for box86!