### PR TITLE
Fix rk3399 PKGBUILD

### DIFF
--- a/pkgbuilds/PKGBUILD-rk3399
+++ b/pkgbuilds/PKGBUILD-rk3399
@@ -19,26 +19,12 @@ pkgver() {
 	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
-prepare() {
-	cd "${srcdir}/${pkgname%-rk3399-git}"
-	if [[ ! -d ./build ]]; then
-		mkdir build && cd build
-		cmake .. -DRK3399=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-	fi
-}
-
 build() {
-	cd "$srcdir/${pkgname%-rk3399-git}/build"
-	make -j$(nproc)
+	cmake -B build -S "${pkgname%-rk3399-git}" -DRK3399=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr
+	make -C build
 }
 
 package() {
-	cd "$srcdir/${pkgname%-arm-git}/build"
+	cd "$srcdir/${pkgname%-rk3399-git}/build"
 	make DESTDIR="${pkgdir}/" install
-	# /usr/local/bin isn't in PATH by the default,
-	# we should move it to /usr/bin
-	cd ${pkgdir}
-	mv usr/local/bin/ usr/bin/
-	# cleanup when dir is empty
-	rmdir usr/local || exit 0
 }


### PR DESCRIPTION
This PR makes some changes & fixes to the Arch Linux PKGBUILD for the RK3399:

* Fixes an apparent copy-paste mistake in the `package()` step;
* Sets `-DCMAKE_INSTALL_PREFIX=/usr` using CMake, so that the step moving the files from `/usr/local` is no longer necessary.  This also fixes the `/etc/binfmt.d/box86.conf` file, which otherwise still points to `/usr/local/bin/box86`.
* Runs `cmake` as part of the build, instead of in the prepare stage, and runs it using the `-B ... -S` options, as recommended in https://wiki.archlinux.org/title/CMake_package_guidelines#Specifying_directories
* Removes the `-j` flag from `make`, as in Arch Linux this is something that is normally set via `MAKEFLAGS` in [makepkg.conf](https://man.archlinux.org/man/makepkg.conf.5) instead.
 
I think it could be a good idea to repeat these changes for the other pkgbuild files - the `-DCMAKE_INSTALL_PREFIX` one in particular.