### PR TITLE
Fix Android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,8 @@ elseif(PHYTIUM)
     add_definitions(-DPHYTIUM)
     add_definitions(-pipe -march=armv8.1-a+simd+crypto -mfpu=neon-fp-armv8 -mfloat-abi=hard)
     set(CMAKE_ASM_FLAGS  "-pipe -march=armv8.1-a+simd+crypto -mfpu=neon-fp-armv8 -mfloat-abi=hard")
+elseif(ANDROID)
+    add_definitions(-DANDROID)
 elseif(ARM_DYNAREC)
     #if DYNAREC is selected alone, without any arch
     set(CMAKE_ASM_FLAGS  "-pipe -march=armv7-a+simd -mfpu=neon")

--- a/src/wrapped/wrappedlibc.c
+++ b/src/wrapped/wrappedlibc.c
@@ -2874,10 +2874,12 @@ EXPORT int my_semctl(x86emu_t* emu, int semid, int semnum, int cmd, union semun 
   return  ((iFiiiV_t)f)(semid, semnum, cmd, b);
 }
 
+#ifndef ANDROID
 EXPORT int my_on_exit(x86emu_t* emu, void* f, void* args)
 {
     return on_exit(findon_exitFct(f), args);
 }
+#endif
 
 
 EXPORT char** my_environ = NULL;


### PR DESCRIPTION
It looks like the Android support from https://github.com/ptitSeb/box86/pull/372 stopped compiling at some point, so this PR fixes it. The `on_exit()` function doesn't exist on Android, and the `ANDROID` C preprocessor macro wasn't being defined.