### PR TITLE
Various packaging improvements

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -5,7 +5,7 @@ Copyright: © 2022 Sebastien Chevalier
 License: MIT
 
 License: MIT
-  Copyright (c) 2018-2021 Sebastien Chevalier ("ptitSeb")
+ Copyright (c) 2018-2021 Sebastien Chevalier ("ptitSeb")
  .
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/debian/lintian-override
+++ b/debian/lintian-override
@@ -1,0 +1,1 @@
+box86: no-manual-page

--- a/debian/rules
+++ b/debian/rules
@@ -9,4 +9,4 @@ override_dh_auto_configure:
 	      -DARM_DYNAREC=1
 
 override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+	dh_shlibdeps --exclude=libgcc_s.so.1 --exclude=libpng12.so.0 --exclude=libstdc++.so.5 --exclude=libstdc++.so.6 

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export DEB_BUILD_OPTIONS='nostrip'
+export DEB_BUILD_MAINT_OPTIONS = nostrip
 
 %:
 	dh $@  

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,5 @@
 #!/usr/bin/make -f
 
-export DEB_BUILD_MAINT_OPTIONS = nostrip
-
 %:
 	dh $@  
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_BUILD_OPTIONS='nostrip'
 
 %:
 	dh $@  

--- a/debian/rules
+++ b/debian/rules
@@ -6,4 +6,7 @@
 override_dh_auto_configure:
 	dh_auto_configure -- \
 	      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-		  -DARM_DYNAREC=1
+	      -DARM_DYNAREC=1
+
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+
 %:
 	dh $@  
 

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -123,5 +123,5 @@ Nvidia don't provide armhf libraries for their GPU drivers at this moment so the
 
 Debian Packaging
 ----
-Box86 can also be packaged into a .deb file with `dpkg-buildpackage -us -uc -nc`.
+Box86 can also be packaged into a .deb file with `DEB_BUILD_OPTIONS=nostrip dpkg-buildpackage -us -uc -nc`.
 

--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -118,3 +118,10 @@ They are very basic and don't test much for now.
 Note about devices with Tegra X1 and newer.
 
 Nvidia don't provide armhf libraries for their GPU drivers at this moment so there is no special variable to compile it for them as it would be missleading for many people. If you still want to use it wihout GPU acceleration, building it with RPI4 configuration should work just fine. As instalation of Mesa can break Nvidia driver, safest option is usage of chroot.
+
+----
+
+Debian Packaging
+----
+Box86 can also be packaged into a .deb file with `dpkg-buildpackage -us -uc -nc`.
+


### PR DESCRIPTION
This pr is to prevent the following error from occurring:
```
make[1]: Leaving directory '/home/pi/Downloads/box86/obj-arm-linux-gnueabihf'
   dh_installdocs
   dh_installchangelogs
   dh_perl
   dh_link
   dh_strip_nondeterminism
   dh_compress
   dh_fixperms
   dh_missing
   dh_strip
strip: Unable to recognise the format of the input file `debian/box86/usr/lib/i386-linux-gnu/libgcc_s.so.1'
dh_strip: error: strip --remove-section=.comment --remove-section=.note --strip-unneeded debian/box86/usr/lib/i386-linux-gnu/libgcc_s.so.1 returned exit code 1
dh_strip: error: Aborting due to earlier error
make: *** [debian/rules:6: binary] Error 2
dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2
```