### PR TITLE
Make postinst script failsafe

### DIFF
--- a/postinst
+++ b/postinst
@@ -1,2 +1,4 @@
 #!/bin/sh
-systemctl restart systemd-binfmt
+if [ -d '/run/systemd/system' ]; then
+    systemctl restart systemd-binfmt || :
+fi


### PR DESCRIPTION
"systemctl restart systemd-binfmt" can only succeed when systemd is the used init system and when the binfmt_misc kernel module is available. The kernel module may not be available right after a kernel upgrade or within a container where it needs to be loaded on the host. 

The common check for whether systemd is used or not is to check for the directory "/run/systemd/system" which is hereby added.

Since modprobe may not be available and within a container always fails (regardless whether the host provides it), the service restart is allowed to fail without failing the postinst script and hence the package install. If the service restart fails, Box86 support in binfmt becomes effective on next system restart, given binfmt_misc is generally available. Furthermore binfmt is a convenience feature while generally Box86 can be used without it. It is hence no reason to hard fail the package install when systemd-binfmt fails for any reason.

With this change, the postinst script could be added to the [debhelper sources](https://github.com/ptitSeb/box86/tree/master/debian).