### PR TITLE
steam: disable modern login and pass arguments to client

### DIFF
--- a/install_steam.sh
+++ b/install_steam.sh
@@ -21,7 +21,7 @@ cd ../ && rm -rf ./tmp/
 echo "#!/bin/bash
 export STEAMOS=1
 export STEAM_RUNTIME=1
-~/steam/bin/steam steam://open/minigameslist" > steam
+~/steam/bin/steam -noreactlogin steam://open/minigameslist $@" > steam
 
 # make script executable and move
 chmod +x steam


### PR DESCRIPTION
disables the new react ui because the browser isn't available for now and passes the additional command line arguments to the main client