### PR TITLE
Modify sizeof(instsize_t) to 1 byte

### DIFF
--- a/src/dynarec/dynablock_private.h
+++ b/src/dynarec/dynablock_private.h
@@ -4,8 +4,8 @@
 typedef struct dynablocklist_s  dynablocklist_t;
 
 typedef struct instsize_s {
-    unsigned int x86:4;
-    unsigned int nat:4;
+    unsigned char x86:4;
+    unsigned char nat:4;
 } instsize_t;
 
 typedef struct dynablock_s {


### PR DESCRIPTION
instsize_t uses 1 byte acturlly, while alloced 4 bytes before.