### PR TITLE
Docs: Add note about installing the correct package from my apt repo on arm64.

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -10,6 +10,8 @@ wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo 
 sudo apt update && sudo apt install box86 -y
 ```
 
+**Note:** On a 64bit OS, install the `box86:armhf` package.
+
 Alternatively, you can generate your own package using the [instructions below](https://github.com/ptitSeb/box86/blob/master/docs/COMPILE.md#debian-packaging). 
 
 #### for Pandora


### PR DESCRIPTION
On 64bit OS's the installing the `box86` package installs an old version that has the arch set to `arm64`.
To get the latest version, the `box86:armhf` package has to be installed.

I'll remove the bad package from my repo, but the note still applies.