### PR TITLE
Ignore steam dbus warning

### DIFF
--- a/install_steam.sh
+++ b/install_steam.sh
@@ -21,6 +21,7 @@ cd ../ && rm -rf ./tmp/
 echo "#!/bin/bash
 export STEAMOS=1
 export STEAM_RUNTIME=1
+export DBUS_FATAL_WARNINGS=0
 ~/steam/bin/steam -noreactlogin steam://open/minigameslist $@" > steam
 
 # make script executable and move


### PR DESCRIPTION
fix error like
```
dbus[8661]: arguments to dbus_message_new_method_call() were incorrect, assertion "path != NULL" failed in file ../../../dbus/dbus-message.c line 1362.
This is normally a bug in some application using the D-Bus library.

  D-Bus not built with -rdynamic so unable to print a backtrace
```
ref:
https://github.com/diasurgical/devilutionX/issues/20
https://bugs.launchpad.net/ubuntu/+source/libsdl2/+bug/1775067