### PR TITLE
add -dnogit=1 flag to debian rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 	      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	      -DARM_DYNAREC=1
+		  -DNOGIT=1
 
 override_dh_shlibdeps:
 	dh_shlibdeps --exclude=libgcc_s.so.1 --exclude=libpng12.so.0 --exclude=libstdc++.so.5 --exclude=libstdc++.so.6 

--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -194,5 +194,5 @@ NVIDIA doesn't provide armhf libraries for their GPU drivers at this time. There
 
 Debian Packaging
 ----
-Box86 can also be packaged into a .deb file with `DEB_BUILD_OPTIONS=nostrip dpkg-buildpackage -us -uc -nc`.
+Box86 can also be packaged into a .deb file ***using the source code zip from the releases page*** with `DEB_BUILD_OPTIONS=nostrip dpkg-buildpackage -us -uc -nc`. Configure any additional cmake options you might want in `debian/rules`.
 


### PR DESCRIPTION
Debian package maintainers typically prefer using a .zip of the release of software instead of pulling from the master source tree to build their package.