### PR TITLE
docs/COMPILE.md: Use trusted.gpg.d

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -6,7 +6,7 @@ You can use [@Itai-Nelken](https://github.com/Itai-Nelken)'s apt repository to i
 
 ```
 sudo wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list
-wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo apt-key add -
+wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg
 sudo apt update && sudo apt install box86 -y
 ```
 


### PR DESCRIPTION
add-key(8) is deprecated and causes warnings to be reported when running apt-get update after adding the repo.