### PR TITLE
Fix for Steamwebhelper failing to start.

### DIFF
--- a/install_steam.sh
+++ b/install_steam.sh
@@ -18,11 +18,11 @@ mv ./usr/* ../
 cd ../ && rm -rf ./tmp/
 
 # create run script
-echo "#!/bin/bash
+echo '#!/bin/bash
 export STEAMOS=1
 export STEAM_RUNTIME=1
 export DBUS_FATAL_WARNINGS=0
-~/steam/bin/steam $@" > steam
+~/steam/bin/steam $@' > steam
 
 # make script executable and move
 chmod +x steam
@@ -35,7 +35,7 @@ if [ ${MACHINE_TYPE} == 'aarch64' ] && [ -f '/etc/debian_version' ]; then
  sudo dpkg --add-architecture armhf # enable installation of armhf libraries
  sudo apt update # update package lists with the newly added arch
  # install the libraries that Steam requires
- sudo apt install libc6:armhf libsdl2-2.0-0:armhf libsdl2-image-2.0-0:armhf libsdl2-mixer-2.0-0:armhf libsdl2-ttf-2.0-0:armhf libopenal1:armhf libpng16-16:armhf libfontconfig1:armhf libxcomposite1:armhf libbz2-1.0:armhf libxtst6:armhf libsm6:armhf libice6:armhf libgl1:armhf libxinerama1:armhf libxdamage1:armhf
+ sudo apt install libc6:armhf libsdl2-2.0-0:armhf libsdl2-image-2.0-0:armhf libsdl2-mixer-2.0-0:armhf libsdl2-ttf-2.0-0:armhf libopenal1:armhf libpng16-16:armhf libfontconfig1:armhf libxcomposite1:armhf libbz2-1.0:armhf libxtst6:armhf libsm6:armhf libice6:armhf libgl1:armhf libxinerama1:armhf libxdamage1:armhf libibus-1.0-5
  # this one is not there all the time, so just try it...
  sudo apt install libncurses5:armhf 
 


### PR DESCRIPTION
Fixes #945 and probably other steamwebhelper-related issues.

Fixes :
$@ was not escaped so it was not included in the steam launch script. Which means that any parameter were ignored when starting steam.

Added libibus-1.0-5 package that is required by newer versions of steam. I didn't had to specify armhf on Pi 5 so I don't know if it's required for other platforms?