### PR TITLE
build: fix PKGBUILD-rk3xxx, _rkmodel was never set

### DIFF
--- a/pkgbuilds/PKGBUILD-rk3xxx
+++ b/pkgbuilds/PKGBUILD-rk3xxx
@@ -13,6 +13,7 @@ provides=("${pkgname%-git}" "${pkgname%-rk3xxx-git}-git" "${pkgname%-rk3xxx-git}
 conflicts=("${pkgname%-git}" "${pkgname%-rk3xxx-git}-git" "${pkgname%-rk3xxx-git}")
 source=('git+https://github.com/ptitSeb/box86')
 md5sums=('SKIP')
+_rkmodel=`tr -d '\0' < /proc/device-tree/compatible`
 
 pkgver() {
 	cd "$srcdir/${pkgname%-rk3xxx-git}"


### PR DESCRIPTION
Code was taken from box64's PKGBUILD-rk3xxx