### PR TITLE
Fix missing space in PKGBUILD-rk3xxx causing syntax error

### DIFF
--- a/pkgbuilds/PKGBUILD-rk3xxx
+++ b/pkgbuilds/PKGBUILD-rk3xxx
@@ -23,7 +23,7 @@ pkgver() {
 prepare() {
 	cd "${srcdir}/${pkgname%-rk3xxx-git}"
 	# Check for RockChip version number
-	if [[ ${_rkmodel} =~ "rk3288"]]; then
+	if [[ ${_rkmodel} =~ "rk3288" ]]; then
 		_rksuffix=3288
 	elif [[ ${_rkmodel} =~ "rk3399" ]]; then
 		_rksuffix=3399	


### PR DESCRIPTION
Went to compile on my PinePhone Pro ( RK3399 ) and noticed a syntax error from a missing space.