### PR TITLE
Exclude x86 libunwind from shlibdeps in Debian packaging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,9 @@ override_dh_auto_configure:
 		  -DNOGIT=1
 
 override_dh_shlibdeps:
-	dh_shlibdeps --exclude=libgcc_s.so.1 --exclude=libpng12.so.0 --exclude=libstdc++.so.5 --exclude=libstdc++.so.6 
+	dh_shlibdeps \
+		--exclude=libgcc_s.so.1 \
+		--exclude=libpng12.so.0 \
+		--exclude=libstdc++.so.5 \
+		--exclude=libstdc++.so.6 \
+		--exclude=libunwind.so.8


### PR DESCRIPTION
The other packaged x86 libraries in x86lib/ are excluded from dh_shlibdeps's scanning for dependencies, but libunwind.so.8 is missing from the list of exclusions, causing Debian package builds to fail if x86 binaries of libc and liblzma aren't installed on the build host.